### PR TITLE
Another kill method

### DIFF
--- a/datalad_next/runners/protocols.py
+++ b/datalad_next/runners/protocols.py
@@ -27,5 +27,6 @@ class StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
         assert fd == 1
         self.send_result(data)
 
-    def timeout(self, fd):
-        raise TimeoutError(f"Runner timeout {fd}")
+    def timeout(self, fd) -> bool:
+        self.send_result(('timeout', fd))
+        return False

--- a/datalad_next/runners/tests/test_run.py
+++ b/datalad_next/runners/tests/test_run.py
@@ -54,6 +54,36 @@ def test_run_instant_kill():
     assert sp.runner.process.returncode is not None
 
 
+def test_run_kill_non_terminating():
+
+    py_prog = '''
+import sys
+import time
+
+i = 0
+while True:
+    try:
+        print(i, flush=True)
+        i += 1
+        time.sleep(1)
+    except BaseException as e:
+        pass
+'''
+
+    with run(
+        cmd=[sys.executable, '-c', py_prog],
+        protocol_class=StdOutCaptureGeneratorProtocol,
+        timeout=1.0
+    ) as sp:
+        for i in range(3):
+            print(next(sp))
+    if os.name == 'posix':
+        print(sp.return_code)
+        #assert sp.runner.process.returncode < 0
+    print(sp.return_code)
+    #assert sp.runner.process.returncode is not None
+
+
 def test_run_cwd(tmp_path):
     with run([
         sys.executable, '-c',


### PR DESCRIPTION
This PR demonstrates another way of integrating process killing into the `__exit__`-handler of a context.

Adds a test with non-terminating subprocess

Note: this is a mechanisms-demo, it works but is not prroperly doc-stringed and might benefit from more comments